### PR TITLE
lib/result: add initial prototype for wiby --result

### DIFF
--- a/bin/wiby.js
+++ b/bin/wiby.js
@@ -33,7 +33,10 @@ yargs
         })
     },
     (argv) => {
-      result(argv.dependent)
+      result(argv.dependent).catch(e => {
+        console.error(e)
+        process.exitCode = e.code || 1
+      })
     }
   )
   .help()

--- a/bin/wiby.js
+++ b/bin/wiby.js
@@ -31,6 +31,6 @@ yargs
   )
   .help()
   .strict()
-  .argv
+  .parse()
 
 // Usage: wiby test --dependent=URL

--- a/bin/wiby.js
+++ b/bin/wiby.js
@@ -24,9 +24,16 @@ yargs
   .command(
     'result',
     'Fetch the results of your tests',
-    () => {},
-    () => {
-      result()
+    (yargs) => {
+      yargs
+        .option('dependent', {
+          desc: 'URL of a dependent',
+          demandOption: true,
+          type: 'string'
+        })
+    },
+    (argv) => {
+      result(argv.dependent)
     }
   )
   .help()
@@ -34,3 +41,4 @@ yargs
   .parse()
 
 // Usage: wiby test --dependent=URL
+// Usage: wiby result --dependent=URL

--- a/lib/github.js
+++ b/lib/github.js
@@ -121,3 +121,19 @@ async function createBranch (owner, repo, commitSha, branch) {
     ref: `refs/heads/${branch}`
   })
 }
+
+module.exports.getChecks = async function getChecks (owner, repo, branch) {
+  return octokit.checks.listForRef({
+    owner,
+    repo,
+    ref: branch
+  })
+}
+
+module.exports.getCommitStatusesForRef = async function getCommitStatusesForRef (owner, repo, branch) {
+  return octokit.repos.listCommitStatusesForRef({
+    owner,
+    repo,
+    ref: branch
+  })
+}

--- a/lib/github.js
+++ b/lib/github.js
@@ -10,8 +10,7 @@ const graphqlWithAuth = graphql.defaults({
   }
 })
 
-module.exports.getPackageJson =
-async function getPackageJson (owner, repo) {
+module.exports.getPackageJson = async function getPackageJson (owner, repo) {
   try {
     const resp = await graphqlWithAuth({
       query: `query($owner: String!, $repo: String!) {
@@ -36,8 +35,7 @@ async function getPackageJson (owner, repo) {
   }
 }
 
-module.exports.getPermissions =
-async function getPermissions (owner, repo) {
+module.exports.getPermissions = async function getPermissions (owner, repo) {
   try {
     const resp = await graphqlWithAuth({
       query: `query($owner: String!, $repo: String!) {
@@ -58,8 +56,7 @@ async function getPermissions (owner, repo) {
   }
 }
 
-module.exports.getShas =
-async function getShas (owner, repo) {
+module.exports.getShas = async function getShas (owner, repo) {
   const resp = await octokit.repos.listCommits({
     owner,
     repo,
@@ -70,11 +67,8 @@ async function getShas (owner, repo) {
   return [headSha, treeSha]
 }
 
-module.exports.createBlob =
-async function createBlob (owner, repo, file) {
-  const {
-    data: { sha: blobSha }
-  } = await octokit.git.createBlob({
+module.exports.createBlob = async function createBlob (owner, repo, file) {
+  const { data: { sha: blobSha } } = await octokit.git.createBlob({
     owner,
     repo,
     content: file,
@@ -84,7 +78,7 @@ async function createBlob (owner, repo, file) {
 }
 
 module.exports.createTree = async function createTree (owner, repo, treeSha, blobSha) {
-  const resp = await octokit.git.createTree({
+  const { data: { sha: newTreeSha } } = await octokit.git.createTree({
     owner,
     repo,
     base_tree: treeSha,
@@ -95,25 +89,21 @@ module.exports.createTree = async function createTree (owner, repo, treeSha, blo
       Accept: 'application/json'
     }
   })
-  const newTreeSha = resp.data.sha
   return newTreeSha
 }
 
-module.exports.createCommit =
-async function createCommit (owner, repo, message, newTreeSha, headSha) {
-  const resp = await octokit.git.createCommit({
+module.exports.createCommit = async function createCommit (owner, repo, message, newTreeSha, headSha) {
+  const { data: { sha: commitSha } } = await octokit.git.createCommit({
     owner,
     repo,
     message: message,
     tree: newTreeSha,
     parents: [headSha]
   })
-  const commitSha = resp.data.sha
   return commitSha
 }
 
-module.exports.createBranch =
-async function createBranch (owner, repo, commitSha, branch) {
+module.exports.createBranch = async function createBranch (owner, repo, commitSha, branch) {
   await octokit.git.createRef({
     owner,
     repo,

--- a/lib/result.js
+++ b/lib/result.js
@@ -27,8 +27,7 @@ module.exports = async function (url) {
 }
 
 const getBranchName = module.exports.getBranchName = async function getBranchName (dep) {
-  const branch = `wiby-${dep}`
-  return branch
+  return `wiby-${dep}`
 }
 
 const getResultForEachRun = module.exports.getResultForEachRun = function getResultForEachRun (runs) {

--- a/lib/result.js
+++ b/lib/result.js
@@ -1,3 +1,44 @@
-module.exports = () => {
-  console.log('wiby result')
+const test = require('./test')
+const github = require('./github')
+const gitURLParse = require('git-url-parse')
+
+module.exports = async function (url) {
+  const parentPkgJSON = await test.getLocalPackageJSON()
+  const parentPkgInfo = gitURLParse(parentPkgJSON.repository.url)
+  console.log(`Parent module: ${parentPkgInfo.owner}/${parentPkgJSON.name}`)
+
+  const dependentPkgInfo = gitURLParse(url)
+  const dependentPkgJSON = await github.getPackageJson(dependentPkgInfo.owner, dependentPkgInfo.name)
+  console.log(`Dependent module: ${dependentPkgInfo.owner}/${dependentPkgInfo.name}`)
+
+  if (!test.checkPackageInPackageJSON(parentPkgJSON.name, dependentPkgJSON)) {
+    throw new Error('Dependency not found in package.json')
+  }
+
+  const branch = await getBranchName(parentPkgJSON.name)
+  let resp = await github.getChecks(dependentPkgInfo.owner, dependentPkgInfo.name, branch)
+  if (resp.data.check_runs.length === 0) {
+    resp = await github.getCommitStatusesForRef(dependentPkgInfo.owner, dependentPkgInfo.name, branch)
+  }
+  const runs = resp.data.check_runs || resp.data
+  console.log(`Tests on branch "${branch}"`)
+  const results = getResultForEachRun(runs)
+  console.log(results)
+}
+
+const getBranchName = module.exports.getBranchName = async function getBranchName (dep) {
+  const branch = `wiby-${dep}`
+  return branch
+}
+
+const getResultForEachRun = module.exports.getResultForEachRun = function getResultForEachRun (runs) {
+  const results = []
+  runs.forEach((check) => {
+    if (check.status === 'queued') {
+      results.push([check.name, check.status])
+    } else {
+      results.push([check.name, check.conclusion])
+    }
+  })
+  return results
 }

--- a/lib/result.js
+++ b/lib/result.js
@@ -12,7 +12,7 @@ module.exports = async function (url) {
   console.log(`Dependent module: ${dependentPkgInfo.owner}/${dependentPkgInfo.name}`)
 
   if (!test.checkPackageInPackageJSON(parentPkgJSON.name, dependentPkgJSON)) {
-    throw new Error('Dependency not found in package.json')
+    throw new Error(`${parentPkgInfo.owner}/${parentPkgJSON.name} not found in the package.json of ${dependentPkgInfo.owner}/${dependentPkgInfo.name}`)
   }
 
   const branch = await getBranchName(parentPkgJSON.name)

--- a/lib/result.js
+++ b/lib/result.js
@@ -31,13 +31,10 @@ const getBranchName = module.exports.getBranchName = async function getBranchNam
 }
 
 const getResultForEachRun = module.exports.getResultForEachRun = function getResultForEachRun (runs) {
-  const results = []
-  runs.forEach((check) => {
+  return runs.map((check) => {
     if (check.status === 'queued') {
-      results.push([check.name, check.status])
-    } else {
-      results.push([check.name, check.conclusion])
+      return [check.name, check.status]
     }
+    return [check.name, check.conclusion]
   })
-  return results
 }

--- a/lib/test.js
+++ b/lib/test.js
@@ -22,14 +22,12 @@ module.exports = async function (url) {
   await pushPatch(patchedPackageJSON, dependentPkgInfo.owner, dependentPkgInfo.name, parentPkgJSON.name)
 }
 
-const getCommitHash = module.exports.getCommitHash =
-async function getCommitHash (owner, repo) {
-  const headSha = (await github.getShas(owner, repo))[0]
+const getCommitHash = module.exports.getCommitHash = async function getCommitHash (owner, repo) {
+  const [headSha] = await github.getShas(owner, repo)
   return headSha
 }
 
-const checkPackageInPackageJSON = module.exports.checkPackageInPackageJSON =
-function checkPackageInPackageJSON (dep, packageJSON) {
+const checkPackageInPackageJSON = module.exports.checkPackageInPackageJSON = function checkPackageInPackageJSON (dep, packageJSON) {
   return Object.prototype.hasOwnProperty.call(packageJSON.dependencies, dep)
 }
 
@@ -63,7 +61,7 @@ async function pushPatch (packageJSON, owner, repo, dep) {
   const file = JSON.stringify(packageJSON, null, 2) + '\n' // assumes package.json is using two spaces
   const encodedFile = Buffer.from(file).toString('base64')
   const message = `wiby: update ${dep}`
-  const branch = `wiby-${dep}`
+  const branch = await require('./result').getBranchName(dep)
 
   const [headSha, treeSha] = await github.getShas(owner, repo)
   const blobSha = await github.createBlob(owner, repo, encodedFile)

--- a/package-lock.json
+++ b/package-lock.json
@@ -133,24 +133,44 @@
       }
     },
     "@octokit/auth-token": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.1.tgz",
-      "integrity": "sha512-NB81O5h39KfHYGtgfWr2booRxp2bWOJoqbWwbyUg2hw6h35ArWYlAST5B3XwAkbdcx13yt84hFXyFP5X0QToWA==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.2.tgz",
+      "integrity": "sha512-jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==",
       "requires": {
-        "@octokit/types": "^4.0.1"
+        "@octokit/types": "^5.0.0"
+      },
+      "dependencies": {
+        "@octokit/types": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.2.0.tgz",
+          "integrity": "sha512-XjOk9y4m8xTLIKPe1NFxNWBdzA2/z3PFFA/bwf4EoH6oS8hM0Y46mEa4Cb+KCyj/tFDznJFahzQ0Aj3o1FYq4A==",
+          "requires": {
+            "@types/node": ">= 8"
+          }
+        }
       }
     },
     "@octokit/core": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-2.5.3.tgz",
-      "integrity": "sha512-23AHK9xBW0v79Ck8h5U+5iA4MW7aosqv+Yr6uZXolVGNzzHwryNH5wM386/6+etiKUTwLFZTqyMU9oQpIBZcFA==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-2.5.4.tgz",
+      "integrity": "sha512-HCp8yKQfTITYK+Nd09MHzAlP1v3Ii/oCohv0/TW9rhSLvzb98BOVs2QmVYuloE6a3l6LsfyGIwb6Pc4ycgWlIQ==",
       "requires": {
         "@octokit/auth-token": "^2.4.0",
         "@octokit/graphql": "^4.3.1",
         "@octokit/request": "^5.4.0",
-        "@octokit/types": "^4.0.1",
+        "@octokit/types": "^5.0.0",
         "before-after-hook": "^2.1.0",
         "universal-user-agent": "^5.0.0"
+      },
+      "dependencies": {
+        "@octokit/types": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.2.0.tgz",
+          "integrity": "sha512-XjOk9y4m8xTLIKPe1NFxNWBdzA2/z3PFFA/bwf4EoH6oS8hM0Y46mEa4Cb+KCyj/tFDznJFahzQ0Aj3o1FYq4A==",
+          "requires": {
+            "@types/node": ">= 8"
+          }
+        }
       }
     },
     "@octokit/endpoint": {
@@ -174,11 +194,21 @@
       }
     },
     "@octokit/plugin-paginate-rest": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.2.1.tgz",
-      "integrity": "sha512-/tHpIF2XpN40AyhIq295YRjb4g7Q5eKob0qM3thYJ0Z+CgmNsWKM/fWse/SUR8+LdprP1O4ZzSKQE+71TCwK+w==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.3.0.tgz",
+      "integrity": "sha512-Ye2ZJreP0ZlqJQz8fz+hXvrEAEYK4ay7br1eDpWzr6j76VXs/gKqxFcH8qRzkB3fo/2xh4Vy9VtGii4ZDc9qlA==",
       "requires": {
-        "@octokit/types": "^4.0.1"
+        "@octokit/types": "^5.2.0"
+      },
+      "dependencies": {
+        "@octokit/types": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.2.0.tgz",
+          "integrity": "sha512-XjOk9y4m8xTLIKPe1NFxNWBdzA2/z3PFFA/bwf4EoH6oS8hM0Y46mEa4Cb+KCyj/tFDznJFahzQ0Aj3o1FYq4A==",
+          "requires": {
+            "@types/node": ">= 8"
+          }
+        }
       }
     },
     "@octokit/plugin-request-log": {
@@ -187,18 +217,18 @@
       "integrity": "sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw=="
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "3.13.3",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.13.3.tgz",
-      "integrity": "sha512-DlbMy6eZe4g67oqfmSS8H1DUYtnSVNrJZdUO77QpEphO8uecL4nlWXfUbZ2bNBb0925ZrRDZa4Sa3C2fSp/fgQ==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.17.0.tgz",
+      "integrity": "sha512-NFV3vq7GgoO2TrkyBRUOwflkfTYkFKS0tLAPym7RNpkwLCttqShaEGjthOsPEEL+7LFcYv3mU24+F2yVd3npmg==",
       "requires": {
-        "@octokit/types": "^4.1.4",
+        "@octokit/types": "^4.1.6",
         "deprecation": "^2.3.1"
       },
       "dependencies": {
         "@octokit/types": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-4.1.4.tgz",
-          "integrity": "sha512-W+aHUBA6pEZ8OC1fgfFW1/jrgtkaMVBhNr7jhhBErvbWQY4Ii9Hlf3LAurwcy5XXjz8EYluiCZjHhnQO4GSfNg==",
+          "version": "4.1.10",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-4.1.10.tgz",
+          "integrity": "sha512-/wbFy1cUIE5eICcg0wTKGXMlKSbaAxEr00qaBXzscLXpqhcwgXeS6P8O0pkysBhRfyjkKjJaYrvR1ExMO5eOXQ==",
           "requires": {
             "@types/node": ">= 8"
           }
@@ -231,14 +261,14 @@
       }
     },
     "@octokit/rest": {
-      "version": "17.9.2",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-17.9.2.tgz",
-      "integrity": "sha512-UXxiE0HhGQAPB3WDHTEu7lYMHH2uRcs/9f26XyHpGGiiXht8hgHWEk6fA7WglwwEvnj8V7mkJOgIntnij132UA==",
+      "version": "17.11.2",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-17.11.2.tgz",
+      "integrity": "sha512-4jTmn8WossTUaLfNDfXk4fVJgbz5JgZE8eCs4BvIb52lvIH8rpVMD1fgRCrHbSd6LRPE5JFZSfAEtszrOq3ZFQ==",
       "requires": {
         "@octokit/core": "^2.4.3",
         "@octokit/plugin-paginate-rest": "^2.2.0",
         "@octokit/plugin-request-log": "^1.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "^3.12.2"
+        "@octokit/plugin-rest-endpoint-methods": "3.17.0"
       }
     },
     "@octokit/types": {
@@ -3506,7 +3536,8 @@
       "dependencies": {
         "@babel/code-frame": {
           "version": "7.8.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
           "dev": true,
           "requires": {
             "@babel/highlight": "^7.8.3"
@@ -3514,7 +3545,8 @@
         },
         "@babel/core": {
           "version": "7.8.7",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-rBlqF3Yko9cynC5CCFy6+K/w2N+Sq/ff2BPy+Krp7rHlABIr5epbA7OxVeKoMHB39LZOp1UY5SuLjy6uWi35yA==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.8.3",
@@ -3536,14 +3568,16 @@
           "dependencies": {
             "source-map": {
               "version": "0.5.7",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
               "dev": true
             }
           }
         },
         "@babel/generator": {
           "version": "7.8.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-HKyUVu69cZoclptr8t8U5b6sx6zoWjh8jiUhnuj3MpZuKT2dJ8zPTuiy31luq32swhI0SpwItCIlU8XW7BZeJg==",
           "dev": true,
           "requires": {
             "@babel/types": "^7.8.7",
@@ -3554,14 +3588,16 @@
           "dependencies": {
             "source-map": {
               "version": "0.5.7",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
               "dev": true
             }
           }
         },
         "@babel/helper-builder-react-jsx": {
           "version": "7.8.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-JT8mfnpTkKNCboTqZsQTdGo3l3Ik3l7QIt9hh0O9DYiwVel37VoJpILKM4YFbP2euF32nkQSb+F9cUk9b7DDXQ==",
           "dev": true,
           "requires": {
             "@babel/types": "^7.8.3",
@@ -3570,7 +3606,8 @@
         },
         "@babel/helper-function-name": {
           "version": "7.8.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
           "dev": true,
           "requires": {
             "@babel/helper-get-function-arity": "^7.8.3",
@@ -3580,7 +3617,8 @@
         },
         "@babel/helper-get-function-arity": {
           "version": "7.8.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
           "dev": true,
           "requires": {
             "@babel/types": "^7.8.3"
@@ -3588,12 +3626,14 @@
         },
         "@babel/helper-plugin-utils": {
           "version": "7.8.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
           "dev": true
         },
         "@babel/helper-split-export-declaration": {
           "version": "7.8.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
           "dev": true,
           "requires": {
             "@babel/types": "^7.8.3"
@@ -3601,7 +3641,8 @@
         },
         "@babel/helpers": {
           "version": "7.8.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-VPbe7wcQ4chu4TDQjimHv/5tj73qz88o12EPkO2ValS2QiQS/1F2SsjyIGNnAD0vF/nZS6Cf9i+vW6HIlnaR8w==",
           "dev": true,
           "requires": {
             "@babel/template": "^7.8.3",
@@ -3611,7 +3652,8 @@
         },
         "@babel/highlight": {
           "version": "7.8.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
           "dev": true,
           "requires": {
             "chalk": "^2.0.0",
@@ -3621,12 +3663,14 @@
         },
         "@babel/parser": {
           "version": "7.8.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA==",
           "dev": true
         },
         "@babel/plugin-proposal-object-rest-spread": {
           "version": "7.8.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-8qvuPwU/xxUCt78HocNlv0mXXo0wdh9VT1R04WU8HGOfaOob26pF+9P5/lYjN/q7DHOX1bvX60hnhOvuQUJdbA==",
           "dev": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.8.3",
@@ -3635,7 +3679,8 @@
         },
         "@babel/plugin-syntax-jsx": {
           "version": "7.8.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-WxdW9xyLgBdefoo0Ynn3MRSkhe5tFVxxKNVdnZSh318WrG2e2jH+E9wd/++JsqcLJZPfz87njQJ8j2Upjm0M0A==",
           "dev": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.8.3"
@@ -3643,7 +3688,8 @@
         },
         "@babel/plugin-syntax-object-rest-spread": {
           "version": "7.8.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
           "dev": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.8.0"
@@ -3651,7 +3697,8 @@
         },
         "@babel/plugin-transform-destructuring": {
           "version": "7.8.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-eRJu4Vs2rmttFCdhPUM3bV0Yo/xPSdPw6ML9KHs/bjB4bLA5HXlbvYXPOD5yASodGod+krjYx21xm1QmL8dCJQ==",
           "dev": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.8.3"
@@ -3659,7 +3706,8 @@
         },
         "@babel/plugin-transform-react-jsx": {
           "version": "7.8.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-r0h+mUiyL595ikykci+fbwm9YzmuOrUBi0b+FDIKmi3fPQyFokWVEMJnRWHJPPQEjyFJyna9WZC6Viv6UHSv1g==",
           "dev": true,
           "requires": {
             "@babel/helper-builder-react-jsx": "^7.8.3",
@@ -3669,7 +3717,8 @@
         },
         "@babel/runtime": {
           "version": "7.8.7",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
           "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
@@ -3677,7 +3726,8 @@
         },
         "@babel/template": {
           "version": "7.8.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.8.3",
@@ -3687,7 +3737,8 @@
         },
         "@babel/traverse": {
           "version": "7.8.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.8.3",
@@ -3703,7 +3754,8 @@
         },
         "@babel/types": {
           "version": "7.8.7",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
@@ -3713,17 +3765,20 @@
         },
         "@types/color-name": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
           "dev": true
         },
         "@types/prop-types": {
           "version": "15.7.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
           "dev": true
         },
         "@types/react": {
           "version": "16.9.23",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-SsGVT4E7L2wLN3tPYLiF20hmZTPGuzaayVunfgXzUn1x4uHVsKH6QDJQ/TdpHqwsTLd4CwrmQ2vOgxN7gE24gw==",
           "dev": true,
           "requires": {
             "@types/prop-types": "*",
@@ -3732,12 +3787,14 @@
         },
         "@types/yoga-layout": {
           "version": "1.9.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-OpfgQXWLZn5Dl7mOd8dBNcV8NywXbYYoHjUpa64vJ/RQABaxMzJ5bVicKLGIvIiMnQPtPgKNgXb5jkv9fkOQtw==",
           "dev": true
         },
         "ansi-escapes": {
           "version": "4.3.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
           "dev": true,
           "requires": {
             "type-fest": "^0.11.0"
@@ -3745,12 +3802,14 @@
         },
         "ansi-regex": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
@@ -3758,27 +3817,32 @@
         },
         "ansicolors": {
           "version": "0.3.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
           "dev": true
         },
         "arrify": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
           "dev": true
         },
         "astral-regex": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
           "dev": true
         },
         "auto-bind": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==",
           "dev": true
         },
         "caller-callsite": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
           "dev": true,
           "requires": {
             "callsites": "^2.0.0"
@@ -3786,7 +3850,8 @@
         },
         "caller-path": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
           "dev": true,
           "requires": {
             "caller-callsite": "^2.0.0"
@@ -3794,12 +3859,14 @@
         },
         "callsites": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
           "dev": true
         },
         "cardinal": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-fMEFXYItISlU0HsIXeolHMe8VQU=",
           "dev": true,
           "requires": {
             "ansicolors": "~0.3.2",
@@ -3808,7 +3875,8 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -3818,12 +3886,14 @@
         },
         "ci-info": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
           "dev": true
         },
         "cli-cursor": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
           "dev": true,
           "requires": {
             "restore-cursor": "^3.1.0"
@@ -3831,7 +3901,8 @@
         },
         "cli-truncate": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
           "dev": true,
           "requires": {
             "slice-ansi": "^3.0.0",
@@ -3840,7 +3911,8 @@
         },
         "color-convert": {
           "version": "1.9.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
           "dev": true,
           "requires": {
             "color-name": "1.1.3"
@@ -3848,12 +3920,14 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "dev": true
         },
         "convert-source-map": {
           "version": "1.7.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
           "dev": true,
           "requires": {
             "safe-buffer": "~5.1.1"
@@ -3861,19 +3935,22 @@
           "dependencies": {
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
               "dev": true
             }
           }
         },
         "csstype": {
           "version": "2.6.9",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q==",
           "dev": true
         },
         "debug": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -3881,47 +3958,56 @@
         },
         "emoji-regex": {
           "version": "8.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
           "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "esprima": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
           "dev": true
         },
         "esutils": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
           "dev": true
         },
         "events-to-array": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=",
           "dev": true
         },
         "gensync": {
           "version": "1.0.0-beta.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
           "dev": true
         },
         "globals": {
           "version": "11.12.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
           "dev": true
         },
         "has-flag": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "import-jsx": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-lTuMdQ/mRXC+xQSGPDvAg1VkODlX78j5hZv2tneJ+zuo7GH/XhUF/YVKoeF382a4jO4GYw9jgganbMhEcxwb0g==",
           "dev": true,
           "requires": {
             "@babel/core": "^7.5.5",
@@ -3934,7 +4020,8 @@
         },
         "ink": {
           "version": "2.7.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-s7lJuQDJEdjqtaIWhp3KYHl6WV3J04U9zoQ6wVc+Xoa06XM27SXUY57qC5DO46xkF0CfgXMKkKNcgvSu/SAEpA==",
           "dev": true,
           "requires": {
             "ansi-escapes": "^4.2.1",
@@ -3959,7 +4046,8 @@
           "dependencies": {
             "ansi-styles": {
               "version": "4.2.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
               "dev": true,
               "requires": {
                 "@types/color-name": "^1.1.1",
@@ -3968,7 +4056,8 @@
             },
             "chalk": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
               "dev": true,
               "requires": {
                 "ansi-styles": "^4.1.0",
@@ -3977,7 +4066,8 @@
             },
             "color-convert": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
               "dev": true,
               "requires": {
                 "color-name": "~1.1.4"
@@ -3985,17 +4075,20 @@
             },
             "color-name": {
               "version": "1.1.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
               "dev": true
             },
             "has-flag": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
               "dev": true
             },
             "supports-color": {
               "version": "7.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
               "dev": true,
               "requires": {
                 "has-flag": "^4.0.0"
@@ -4005,7 +4098,8 @@
         },
         "is-ci": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
           "dev": true,
           "requires": {
             "ci-info": "^2.0.0"
@@ -4013,22 +4107,26 @@
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
         },
         "js-tokens": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
           "dev": true
         },
         "jsesc": {
           "version": "2.5.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
           "dev": true
         },
         "json5": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.5"
@@ -4036,12 +4134,14 @@
         },
         "lodash.throttle": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
           "dev": true
         },
         "log-update": {
           "version": "3.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-ILKe88NeMt4gmDvk/eb615U/IVn7K9KWGkoYbdatQ69Z65nj1ZzjM6fHXfcs0Uge+e+EGnMW7DY4T9yko8vWFg==",
           "dev": true,
           "requires": {
             "ansi-escapes": "^3.2.0",
@@ -4051,17 +4151,20 @@
           "dependencies": {
             "ansi-escapes": {
               "version": "3.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
               "dev": true
             },
             "ansi-regex": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
               "dev": true
             },
             "cli-cursor": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
               "dev": true,
               "requires": {
                 "restore-cursor": "^2.0.0"
@@ -4069,22 +4172,26 @@
             },
             "emoji-regex": {
               "version": "7.0.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
               "dev": true
             },
             "mimic-fn": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
               "dev": true
             },
             "onetime": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
               "dev": true,
               "requires": {
                 "mimic-fn": "^1.0.0"
@@ -4092,7 +4199,8 @@
             },
             "restore-cursor": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
               "dev": true,
               "requires": {
                 "onetime": "^2.0.0",
@@ -4101,7 +4209,8 @@
             },
             "string-width": {
               "version": "3.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
               "dev": true,
               "requires": {
                 "emoji-regex": "^7.0.1",
@@ -4111,7 +4220,8 @@
             },
             "strip-ansi": {
               "version": "5.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
               "dev": true,
               "requires": {
                 "ansi-regex": "^4.1.0"
@@ -4119,7 +4229,8 @@
             },
             "wrap-ansi": {
               "version": "5.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
               "dev": true,
               "requires": {
                 "ansi-styles": "^3.2.0",
@@ -4131,7 +4242,8 @@
         },
         "loose-envify": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
           "dev": true,
           "requires": {
             "js-tokens": "^3.0.0 || ^4.0.0"
@@ -4139,17 +4251,20 @@
         },
         "mimic-fn": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
           "dev": true
         },
         "minimist": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         },
         "minipass": {
           "version": "3.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
           "dev": true,
           "requires": {
             "yallist": "^4.0.0"
@@ -4157,24 +4272,28 @@
           "dependencies": {
             "yallist": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
               "dev": true
             }
           }
         },
         "ms": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         },
         "onetime": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
           "dev": true,
           "requires": {
             "mimic-fn": "^2.1.0"
@@ -4182,12 +4301,14 @@
         },
         "path-parse": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
           "dev": true
         },
         "prop-types": {
           "version": "15.7.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
           "dev": true,
           "requires": {
             "loose-envify": "^1.4.0",
@@ -4197,17 +4318,20 @@
         },
         "punycode": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
           "dev": true
         },
         "react-is": {
           "version": "16.13.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
           "dev": true
         },
         "react-reconciler": {
           "version": "0.24.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-gAGnwWkf+NOTig9oOowqid9O0HjTDC+XVGBCAmJYYJ2A2cN/O4gDdIuuUQjv8A4v6GDwVfJkagpBBLW5OW9HSw==",
           "dev": true,
           "requires": {
             "loose-envify": "^1.1.0",
@@ -4218,7 +4342,8 @@
         },
         "redeyed": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=",
           "dev": true,
           "requires": {
             "esprima": "~4.0.0"
@@ -4226,12 +4351,14 @@
         },
         "regenerator-runtime": {
           "version": "0.13.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
           "dev": true
         },
         "resolve": {
           "version": "1.15.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
           "dev": true,
           "requires": {
             "path-parse": "^1.0.6"
@@ -4239,12 +4366,14 @@
         },
         "resolve-from": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
           "dev": true
         },
         "restore-cursor": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
           "dev": true,
           "requires": {
             "onetime": "^5.1.0",
@@ -4262,7 +4391,8 @@
         },
         "scheduler": {
           "version": "0.18.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
           "dev": true,
           "requires": {
             "loose-envify": "^1.1.0",
@@ -4271,17 +4401,20 @@
         },
         "semver": {
           "version": "5.7.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true
         },
         "slice-ansi": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.0.0",
@@ -4291,7 +4424,8 @@
           "dependencies": {
             "ansi-styles": {
               "version": "4.2.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
               "dev": true,
               "requires": {
                 "@types/color-name": "^1.1.1",
@@ -4300,7 +4434,8 @@
             },
             "color-convert": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
               "dev": true,
               "requires": {
                 "color-name": "~1.1.4"
@@ -4308,14 +4443,16 @@
             },
             "color-name": {
               "version": "1.1.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
               "dev": true
             }
           }
         },
         "string-length": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==",
           "dev": true,
           "requires": {
             "astral-regex": "^1.0.0",
@@ -4324,17 +4461,20 @@
           "dependencies": {
             "ansi-regex": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
               "dev": true
             },
             "astral-regex": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
               "dev": true
             },
             "strip-ansi": {
               "version": "5.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
               "dev": true,
               "requires": {
                 "ansi-regex": "^4.1.0"
@@ -4344,7 +4484,8 @@
         },
         "string-width": {
           "version": "4.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -4354,7 +4495,8 @@
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
             "ansi-regex": "^5.0.0"
@@ -4362,7 +4504,8 @@
         },
         "supports-color": {
           "version": "5.5.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -4370,7 +4513,8 @@
         },
         "tap-parser": {
           "version": "10.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-qdT15H0DoJIi7zOqVXDn9X0gSM68JjNy1w3VemwTJlDnETjbi6SutnqmBfjDJAwkFS79NJ97gZKqie00ZCGmzg==",
           "dev": true,
           "requires": {
             "events-to-array": "^1.0.1",
@@ -4380,7 +4524,8 @@
         },
         "tap-yaml": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Rxbx4EnrWkYk0/ztcm5u3/VznbyFJpyXO12dDBHKWiDVxy7O2Qw6MRrwO5H6Ww0U5YhRY/4C/VzWmFPhBQc4qQ==",
           "dev": true,
           "requires": {
             "yaml": "^1.5.0"
@@ -4388,12 +4533,14 @@
         },
         "to-fast-properties": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
           "dev": true
         },
         "treport": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-QCAbFtzIjQN+9k+alo8e6oo8j0eSLsttdahAgNLoC3U36rls8XRy/R11QOhHmPz7CDcB2ar29eLe4OFJoPnsPA==",
           "dev": true,
           "requires": {
             "cardinal": "^2.1.1",
@@ -4408,7 +4555,8 @@
           "dependencies": {
             "ansi-styles": {
               "version": "4.2.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
               "dev": true,
               "requires": {
                 "@types/color-name": "^1.1.1",
@@ -4417,7 +4565,8 @@
             },
             "chalk": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
               "dev": true,
               "requires": {
                 "ansi-styles": "^4.1.0",
@@ -4426,7 +4575,8 @@
             },
             "color-convert": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
               "dev": true,
               "requires": {
                 "color-name": "~1.1.4"
@@ -4434,17 +4584,20 @@
             },
             "color-name": {
               "version": "1.1.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
               "dev": true
             },
             "has-flag": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
               "dev": true
             },
             "supports-color": {
               "version": "7.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
               "dev": true,
               "requires": {
                 "has-flag": "^4.0.0"
@@ -4454,12 +4607,14 @@
         },
         "type-fest": {
           "version": "0.11.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
           "dev": true
         },
         "unicode-length": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Ph/j1VbS3/r77nhoY2WU0GWGjVYOHL3xpKp0y/Eq2e5r0mT/6b649vm7KFO6RdAdrZkYLdxphYVgvODxPB+Ebg==",
           "dev": true,
           "requires": {
             "punycode": "^2.0.0",
@@ -4468,12 +4623,14 @@
           "dependencies": {
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "dev": true
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -4492,7 +4649,8 @@
         },
         "widest-line": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
           "dev": true,
           "requires": {
             "string-width": "^4.0.0"
@@ -4500,7 +4658,8 @@
         },
         "wrap-ansi": {
           "version": "6.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.0.0",
@@ -4510,7 +4669,8 @@
           "dependencies": {
             "ansi-styles": {
               "version": "4.2.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
               "dev": true,
               "requires": {
                 "@types/color-name": "^1.1.1",
@@ -4519,7 +4679,8 @@
             },
             "color-convert": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
               "dev": true,
               "requires": {
                 "color-name": "~1.1.4"
@@ -4527,14 +4688,16 @@
             },
             "color-name": {
               "version": "1.1.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
               "dev": true
             }
           }
         },
         "yaml": {
           "version": "1.8.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-omakb0d7FjMo3R1D2EbTKVIk6dAVLRxFXdLZMEUToeAvuqgG/YuHMuQOZ5fgk+vQ8cx+cnGKwyg+8g8PNT0xQg==",
           "dev": true,
           "requires": {
             "@babel/runtime": "^7.8.7"
@@ -4542,7 +4705,8 @@
         },
         "yoga-layout-prebuilt": {
           "version": "1.9.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-+G5Ojl4/sG78mk5masCL3SRaZtkKXRBhMGf5c+4C1j32jN9KpS4lxVFdYyBi15EHN4gMeK5sIRf83T33TOaDkA==",
           "dev": true,
           "requires": {
             "@types/yoga-layout": "1.9.1"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/pkgjs/wiby#readme",
   "dependencies": {
     "@octokit/graphql": "^4.5.0",
-    "@octokit/rest": "^17.9.2",
+    "@octokit/rest": "^17.11.2",
     "dotenv": "^8.2.0",
     "git-url-parse": "^11.1.2",
     "node-fetch": "^2.6.0",

--- a/test/fixtures/checks.js
+++ b/test/fixtures/checks.js
@@ -1,0 +1,17 @@
+module.exports = [
+  {
+    status: 'queued',
+    conclusion: null,
+    name: 'build (1.x)'
+  }, {
+    status: 'completed',
+    conclusion: 'success',
+    name: 'build (2.x)'
+  }, {
+    status: 'completed',
+    conclusion: 'failure',
+    name: 'build (3.x)'
+  }
+]
+
+module.exports.expected = [['build (1.x)', 'queued'], ['build (2.x)', 'success'], ['build (3.x)', 'failure']]

--- a/test/github.js
+++ b/test/github.js
@@ -11,3 +11,17 @@ tap.test('package.json can be fetched with a valid url', async tap => {
 tap.test('correct permissions returned for GitHub repo', async tap => {
   tap.equal((await github.getPermissions(CONFIG.DEP_ORG, CONFIG.DEP_REPO)), CONFIG.DEP_REPO_PERM)
 }, { skip: !process.env.GITHUB_TOKEN })
+
+tap.test('Shas returned from getShas', async tap => {
+  const [headSha, treeSha] = await github.getShas('pkgjs', 'wiby')
+  tap.notEqual(headSha, null)
+  tap.notEqual(treeSha, null)
+}, { skip: !process.env.GITHUB_TOKEN })
+
+tap.test('Checks fetched for a GitHub repo', async tap => {
+  tap.equal((await github.getChecks('pkgjs', 'wiby', 'master')).status, 200)
+}, { skip: !process.env.GITHUB_TOKEN })
+
+tap.test('Checks fetched for a GitHub repo', async tap => {
+  tap.equal((await github.getCommitStatusesForRef('pkgjs', 'wiby', 'master')).status, 200)
+}, { skip: !process.env.GITHUB_TOKEN })

--- a/test/result.js
+++ b/test/result.js
@@ -1,2 +1,13 @@
+require('dotenv').config()
 const tap = require('tap')
-tap.pass('this is fine')
+const result = require('../lib/result')
+const checks = require('./fixtures/checks')
+
+tap.test('Test correct branch name is returned', async tap => {
+  tap.equal(await result.getBranchName('wiby'), 'wiby-wiby')
+})
+
+tap.test('Test correct status returned from getResultForEachRun', tap => {
+  tap.equal(result.getResultForEachRun(checks).toString(), checks.expected.toString())
+  tap.end()
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->
Basic prototype of `wiby result` which will fetch the most recently completed ci runs for a dependent.

Usage: 
Run `wiby result --dependent dependent_url` from the parent packages directory (like wiby test) and the results for the latest ci runs on the wiby branch will be returned. This prototype assumes `wiby test` has already been run.

Sample output:
```sh
Tests on branch "wiby-i-should-pass"
{
  'build (14.x)': 'success',
  'build (12.x)': 'failure',
  'build (10.x)': 'cancelled'
}
```
<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
