### PR TITLE
lib: handle not published packages

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -67,7 +67,6 @@ async function getShas (owner, repo) {
   })
   const headSha = resp.data[0].sha
   const treeSha = resp.data[0].commit.tree.sha
-  // console.log(`lastSha: ${headSha} treeSha: ${treeSha}`)
   return [headSha, treeSha]
 }
 

--- a/lib/test.js
+++ b/lib/test.js
@@ -1,20 +1,25 @@
 const fsPromises = require('fs').promises
-const fetch = require('node-fetch')
 const github = require('./github')
+const gitURLParse = require('git-url-parse')
 
 module.exports = async function (url) {
-  const dep = await getLocalPackageName()
-  console.log('Got local package name: ', dep)
-  const [org, repo] = getOrgRepo(url)
-  console.log(`Got org: ${org} and repo: ${repo}`)
-  const packageJSON = await github.getPackageJson(org, repo)
-  if (!checkPackageInPackageJSON(dep, packageJSON)) {
+  const parentPkgJSON = await getLocalPackageJSON()
+  const parentPkgInfo = gitURLParse(parentPkgJSON.repository.url)
+  console.log(`Parent module: ${parentPkgInfo.owner}/${parentPkgJSON.name}`)
+
+  const dependentPkgInfo = gitURLParse(url)
+  const dependentPkgJSON = await github.getPackageJson(dependentPkgInfo.owner, dependentPkgInfo.name)
+  console.log(`Dependent module: ${dependentPkgInfo.owner}/${dependentPkgInfo.name}`)
+
+  if (!checkPackageInPackageJSON(parentPkgJSON.name, dependentPkgJSON)) {
     throw new Error('Dependency not found in package.json')
   }
-  const patch = await getPatch(dep)
-  console.log('Created patch: ', patch)
-  const patchedPackageJSON = applyPatch(patch, dep, packageJSON)
-  await pushPatch(patchedPackageJSON, org, repo, dep)
+
+  const commitURL = await getCommitURL(parentPkgInfo.owner, parentPkgInfo.name)
+  console.log('Commit URL to test:', commitURL)
+
+  const patchedPackageJSON = applyPatch(commitURL, parentPkgInfo.name, dependentPkgJSON)
+  await pushPatch(patchedPackageJSON, dependentPkgInfo.owner, dependentPkgInfo.name, parentPkgJSON.name)
 }
 
 const getCommitHash = module.exports.getCommitHash =
@@ -28,65 +33,29 @@ function checkPackageInPackageJSON (dep, packageJSON) {
   return Object.prototype.hasOwnProperty.call(packageJSON.dependencies, dep)
 }
 
-const getOrgRepo = module.exports.getOrgRepo =
-function getOrgRepo (url) {
-  const repoOrgArr = (url.split('github.com'))[1].split('/')
-  const org = repoOrgArr[1]
-  const repo = repoOrgArr[2]
-  return [org, repo]
-}
+const getCommitURL = module.exports.getCommitURL =
+async function getCommitURL (owner, repo, hash) {
+  hash = hash || await getCommitHash(owner, repo)
 
-const getPatch = module.exports.getPatch =
-async function getPatch (dep, hash) {
-  dep = dep || await getLocalPackageName()
-  const [org, repo] = await getGitHubOrgRepo(dep)
-  hash = hash || await getCommitHash(org, repo)
-  const patch = `${org}/${repo}#${hash}`
+  const patch = `${owner}/${repo}#${hash}`
   return patch
 }
 
-const getLocalPackageName = module.exports.getLocalPackageName =
-async function getLocalPackageName (pkgPath) {
+const getLocalPackageJSON = module.exports.getLocalPackageJSON =
+async function getLocalPackageJSON (pkgPath) {
   pkgPath = pkgPath || 'package.json'
-  let pkg = await fsPromises.readFile(pkgPath).catch((err) => {
+  const pkg = await fsPromises.readFile(pkgPath).catch((err) => {
     throw (err)
   })
-  pkg = JSON.parse(pkg)
-  return pkg.name
-}
-
-const getGitHubOrgRepo = module.exports.getGitHubOrgRepo =
-async function getGitHubOrgRepo (dep) {
-  const urlRegex = /github.com\/([^/])+\/[^/]+/g
-  const resp = await fetchRegistryInfo(dep)
-  let org, repo
-  if (resp.repository && resp.repository.url) {
-    let gitUrl = (resp.repository.url).match(urlRegex)
-    if (gitUrl) {
-      gitUrl = gitUrl[0].replace(/(\.git)/g, '')
-      org = getOrgRepo(gitUrl)[0]
-      repo = getOrgRepo(gitUrl)[1]
-    }
-  }
-  if (!org && !repo) {
-    org = 'undefined'
-    repo = 'undefined'
-  }
-  return [org, repo]
-}
-
-const fetchRegistryInfo = module.exports.fetchRegistryInfo =
-async function fetchRegistryInfo (dep) {
-  const resp = await fetch(`https://registry.npmjs.org/${dep}`)
-  return resp.json()
+  return JSON.parse(pkg)
 }
 
 const applyPatch = module.exports.applyPatch =
-function applyPatch (patch, dep, packageJSON) {
-  if (!Object.prototype.hasOwnProperty.call(packageJSON.dependencies, dep)) {
+function applyPatch (patch, module, packageJSON) {
+  if (!Object.prototype.hasOwnProperty.call(packageJSON.dependencies, module)) {
     throw new Error('Dependency not found in package.json')
   }
-  packageJSON.dependencies[dep] = patch
+  packageJSON.dependencies[module] = patch
   return packageJSON
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1561,6 +1561,23 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "git-up": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.1.tgz",
+      "integrity": "sha512-LFTZZrBlrCrGCG07/dm1aCjjpL1z9L3+5aEeI9SBhAqSc+kiA9Or1bgZhQFNppJX6h/f5McrvJt1mQXTFm6Qrw==",
+      "requires": {
+        "is-ssh": "^1.3.0",
+        "parse-url": "^5.0.0"
+      }
+    },
+    "git-url-parse": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.1.2.tgz",
+      "integrity": "sha512-gZeLVGY8QVKMIkckncX+iCq2/L8PlwncvDFKiWkBn9EtCfYDbliRTTp6qzyQ1VMdITUfq7293zDzfpjdiGASSQ==",
+      "requires": {
+        "git-up": "^4.0.0"
+      }
+    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -1865,6 +1882,14 @@
       "dev": true,
       "requires": {
         "has": "^1.0.3"
+      }
+    },
+    "is-ssh": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.1.tgz",
+      "integrity": "sha512-0eRIASHZt1E68/ixClI8bp2YK2wmBPVWEismTs6M+M099jKgrzl/3E976zIbImSIob48N2/XGe9y7ZiYdImSlg==",
+      "requires": {
+        "protocols": "^1.1.0"
       }
     },
     "is-stream": {
@@ -2338,6 +2363,11 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
+    "normalize-url": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
+      "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -2696,6 +2726,26 @@
         "error-ex": "^1.2.0"
       }
     },
+    "parse-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.1.tgz",
+      "integrity": "sha512-d7yhga0Oc+PwNXDvQ0Jv1BuWkLVPXcAoQ/WREgd6vNNoKYaW52KI+RdOFjI63wjkmps9yUE8VS4veP+AgpQ/hA==",
+      "requires": {
+        "is-ssh": "^1.3.0",
+        "protocols": "^1.4.0"
+      }
+    },
+    "parse-url": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.1.tgz",
+      "integrity": "sha512-flNUPP27r3vJpROi0/R3/2efgKkyXqnXwyP1KQ2U0SfFRgdizOdWfvrrvJg1LuOoxs7GQhmxJlq23IpQ/BkByg==",
+      "requires": {
+        "is-ssh": "^1.3.0",
+        "normalize-url": "^3.3.0",
+        "parse-path": "^4.0.0",
+        "protocols": "^1.4.0"
+      }
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -2887,6 +2937,11 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.8.1"
       }
+    },
+    "protocols": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.7.tgz",
+      "integrity": "sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg=="
     },
     "pseudomap": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@octokit/graphql": "^4.5.0",
     "@octokit/rest": "^17.9.2",
     "dotenv": "^8.2.0",
+    "git-url-parse": "^11.1.2",
     "node-fetch": "^2.6.0",
     "yargs": "^15.3.1"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,6 @@ const fs = require('fs').promises
 const tap = require('tap')
 const path = require('path')
 const CONFIG = require('./fixtures/config')
-const localPkg = require('./fixtures/package.json')
 const pkgTest = require('../lib/test')
 
 tap.test('Test correct sha returned for a GitHub repository', async tap => {

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,5 @@
 require('dotenv').config()
+const fs = require('fs').promises
 const tap = require('tap')
 const path = require('path')
 const CONFIG = require('./fixtures/config')
@@ -15,33 +16,14 @@ tap.test('Check if the dependency is listed in the package.json', tap => {
   tap.end()
 })
 
-tap.test('GitHub organisation/owner and repository returned', tap => {
-  tap.equal(pkgTest.getOrgRepo(CONFIG.DEP_URL)[0], CONFIG.DEP_ORG)
-  tap.equal(pkgTest.getOrgRepo(CONFIG.DEP_URL)[1], CONFIG.DEP_REPO)
-  tap.end()
+tap.test('commit url created from github org repo and commit sha', async tap => {
+  tap.equal(await pkgTest.getCommitURL(CONFIG.PKG_ORG, CONFIG.PKG_NAME, CONFIG.PKG_HEAD_SHA), CONFIG.PATCH)
 })
 
-tap.test('patch created from github org repo and commit sha', async tap => {
-  tap.equal(await pkgTest.getPatch(CONFIG.PKG_NAME, CONFIG.PKG_HEAD_SHA), CONFIG.PATCH)
-})
-
-tap.test('Local package.json name returned correctly', async tap => {
+tap.test('Local package.json returned correctly', async tap => {
   const pkgPath = path.join(__dirname, '/fixtures/package.json')
-  tap.equal(await pkgTest.getLocalPackageName(pkgPath), localPkg.name)
-})
-
-tap.test('GitHub org and repo returned when given package name', async tap => {
-  tap.equal((await pkgTest.getGitHubOrgRepo(CONFIG.PKG_NAME))[0], CONFIG.PKG_ORG)
-  tap.equal((await pkgTest.getGitHubOrgRepo(CONFIG.PKG_NAME))[1], CONFIG.PKG_REPO)
-})
-
-tap.test('Check registry info is fetched correctly', async tap => {
-  tap.equal((await pkgTest.fetchRegistryInfo(CONFIG.PKG_NAME))._id, CONFIG.PKG_NAME)
-})
-
-tap.test('undefined returned when given an invalid package name', async tap => {
-  tap.equal((await pkgTest.getGitHubOrgRepo('not-a-package'))[0], 'undefined')
-  tap.equal((await pkgTest.getGitHubOrgRepo('not-a-package'))[1], 'undefined')
+  const expectedPackageJSON = await fs.readFile(pkgPath)
+  tap.looseEqual(await pkgTest.getLocalPackageJSON(pkgPath), JSON.parse(expectedPackageJSON))
 })
 
 tap.test('Check patch applied to package.json successfully', tap => {


### PR DESCRIPTION
This PR removes the need for modules to be published to npm before they can be tested. This involved a bit more refactoring than I first anticipated...
 
To summarise, this PR: 
- Introduces `git-url-parse` module
- Extracts the parent module repository from the local `package.json` using the `git-url-parse` module.
  - This enables us to remove `getGitHubOrgRepo`, `getOrgRepo`, and `fetchRegistryInfo` functions.
- Renames variables such as `dep`
  - These changes were initially to just to help me understand the flow of the program, but I think it is worth keeping more specific naming - although happy to change these. 
- Changes the `getPatch` function name to `getCommitURL`
  - Open to bike-shedding on this function name. I felt it should be changed as when I was working through the code I assumed that the function returned a Git Patch, but it returns the URL that we wish to patch the `package.json` with.
- Removes the tests for the removed functions. Updates the test for `getPatch` where the function has been renamed.
