### PR TITLE
Use semantic-release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,35 +2,8 @@
 
 ## Code of Conduct
 
-The Node.js project has a
-[Code of Conduct](https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md)
-to which all contributors must adhere.
+The Node.js Code of Conduct, which applies to this project, can be found at https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md.
 
-See [details on our policy on Code of Conduct](https://github.com/nodejs/node/blob/master/doc/guides/contributing/code-of-conduct.md).
+## Commit guidelines
 
-<a id="developers-certificate-of-origin"></a>
-## Developer's Certificate of Origin 1.1
-
-By making a contribution to this project, I certify that:
-
-* (a) The contribution was created in whole or in part by me and I
-  have the right to submit it under the open source license
-  indicated in the file; or
-
-* (b) The contribution is based upon previous work that, to the best
-  of my knowledge, is covered under an appropriate open source
-  license and I have the right under that license to submit that
-  work with modifications, whether created in whole or in part
-  by me, under the same open source license (unless I am
-  permitted to submit under a different license), as indicated
-  in the file; or
-
-* (c) The contribution was provided directly to me by some other
-  person who certified (a), (b) or (c) and I have not modified
-  it.
-
-* (d) I understand and agree that this project and the contribution
-  are public and that a record of the contribution (including all
-  personal information I submit with it, including my sign-off) is
-  maintained indefinitely and may be redistributed consistent with
-  this project or the open source license(s) involved.
+- This repository uses `semantic-release` and commits should follow the [Angular Commit Message Conventions](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,4 +6,4 @@ The Node.js Code of Conduct, which applies to this project, can be found at http
 
 ## Commit guidelines
 
-- This repository uses `semantic-release` and commits should follow the [Angular Commit Message Conventions](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines).
+- This repository uses `semantic-release` with default configuration.

--- a/README.md
+++ b/README.md
@@ -38,5 +38,5 @@ Example:
 
 ## Development
 
-- This repository uses `semantic-release` and commits should follow the [Angular Commit Message Conventions](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines).
+- This repository uses `semantic-release` with default configuration.
 - Create a new release by running `npx semantic-release`.

--- a/README.md
+++ b/README.md
@@ -35,3 +35,8 @@ Example:
   [wiby test](./USAGE.md#wiby-test)    Test your dependents
 
   [wiby result](./USAGE.md#wiby-result) Fetch the results of your tests
+
+## Development
+
+- This repository uses `semantic-release` and commits should follow the [Angular Commit Message Conventions](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines).
+- Create a new release by running `npx semantic-release`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiby",
-  "version": "0.1.0",
+  "version": "0.0.0-development",
   "description": "Will I Break You?",
   "bin": {
     "wiby": "bin/wiby"


### PR DESCRIPTION
I'm deliberately saying that the commits _should_ follow the convention and I'm deliberately not adding a linter for that (just to avoid the burden on any potential contributors).

I'll add a config to determine bump levels based off PR labels, but until then - I'm sure we can manage without enforcing anything, so the goal here is that I can publish this using `npx semantic-release`.