### PR TITLE
refactor: using already defined function

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -50,7 +50,7 @@ async function getLocalPackageJSON (pkgPath) {
 
 const applyPatch = module.exports.applyPatch =
 function applyPatch (patch, module, packageJSON) {
-  if (!Object.prototype.hasOwnProperty.call(packageJSON.dependencies, module)) {
+  if (!checkPackageInPackageJSON(module, packageJSON)) {
     throw new Error('Dependency not found in package.json')
   }
   packageJSON.dependencies[module] = patch


### PR DESCRIPTION
This changes the code a bit to use the already defined
checkPackageInPackageJSON function instead of
Object.prototype.hasOwnProperty.call

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
