### PR TITLE
fix: use name from package json within the patch

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -19,7 +19,7 @@ module.exports = async function ({ dependents }) {
       throw new Error(`${parentPkgInfo.owner}/${parentPkgJSON.name} not found in the package.json of ${dependentPkgInfo.owner}/${dependentPkgInfo.name}`)
     }
 
-    const patchedPackageJSON = applyPatch(commitURL, parentPkgInfo.name, dependentPkgJSON)
+    const patchedPackageJSON = applyPatch(commitURL, parentPkgJSON.name, dependentPkgJSON)
     await pushPatch(patchedPackageJSON, dependentPkgInfo.owner, dependentPkgInfo.name, parentPkgJSON.name)
   }
 }

--- a/test/fixtures/config.js
+++ b/test/fixtures/config.js
@@ -3,11 +3,11 @@ module.exports.PATCHED_PKGJSON = Object.assign({}, module.exports.PKGJSON, {
   dependencies: Object.assign(
     {},
     module.exports.PKGJSON.dependencies,
-    { wiby: 'pkgjs/wiby#577c08e8fd5e1b3156ce75b2e5d9e3023dac180e' }
+    { '@pkgjs/wiby': 'pkgjs/wiby#577c08e8fd5e1b3156ce75b2e5d9e3023dac180e' }
   )
 })
 module.exports.PATCH = 'pkgjs/wiby#577c08e8fd5e1b3156ce75b2e5d9e3023dac180e'
-module.exports.PKG_NAME = 'wiby'
+module.exports.PKG_NAME = '@pkgjs/wiby'
 module.exports.PKG_REPO = 'wiby'
 module.exports.PKG_ORG = 'pkgjs'
 module.exports.PKG_HEAD_SHA = '577c08e8fd5e1b3156ce75b2e5d9e3023dac180e'

--- a/test/fixtures/pass/package.json
+++ b/test/fixtures/pass/package.json
@@ -12,6 +12,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "wiby": "*"
+    "@pkgjs/wiby": "*"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -16,7 +16,8 @@ tap.afterEach(async () => {
 })
 
 tap.test('Check if the dependency is listed in the package.json', tap => {
-  tap.equal(pkgTest.checkPackageInPackageJSON(CONFIG.PKG_NAME, CONFIG.PKGJSON), true)
+  tap.equal(pkgTest.checkPackageInPackageJSON(CONFIG.PKG_NAME, CONFIG.PKGJSON), true, `expect ${CONFIG.PKG_NAME} to be in pkg json`)
+  tap.equal(pkgTest.checkPackageInPackageJSON(CONFIG.PKG_REPO, CONFIG.PKGJSON), false, `expect that repo name ${CONFIG.PKG_REPO} does not match scoped pkg name ${CONFIG.PKG_NAME}`)
   tap.equal(pkgTest.checkPackageInPackageJSON('not-a-dep', CONFIG.PKGJSON), false)
   tap.end()
 })


### PR DESCRIPTION
To make myself more familiar with wiby I started testing with two repos created for testing purposes.

The [dependency repo my-dependency-id-a](https://github.com/ghinks/my-dependency-id-a) and the [parent consuming it](https://github.com/ghinks/my-parent)

the target modules would be @gvhinks/my-dependency-id-a and the parent @gvhinks/my-parent.

What I found was that the name from the package.json should be used and not the repo name in the patch as some names will be scoped and we should not assume the repo and package name are the same.



Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

