### PR TITLE
Github Workflow

### DIFF
--- a/.github/workflows/wiby.yaml
+++ b/.github/workflows/wiby.yaml
@@ -5,6 +5,7 @@ on:
     types: [ created ]
 
 env:
+  WIBY_CHECK_NAME: "wiby"
   WIBY_NODE_VERSION: 14
 
 jobs:
@@ -52,7 +53,7 @@ jobs:
           mediaType: |
             previews:
               - antiope
-          name: "wiby"
+          name: ${{ env.WIBY_CHECK_NAME }}
           details_url: "${{ steps.pr.outputs.repo_url }}/actions/runs/${{ github.run_id }}"
           head_sha: ${{ steps.pr.outputs.head_sha }}
           status: "queued"
@@ -92,7 +93,7 @@ jobs:
           mediaType: |
             previews:
               - antiope
-          name: "wiby"
+          name: ${{ env.WIBY_CHECK_NAME }}
           details_url: "${{ steps.pr.outputs.repo_url }}/actions/runs/${{ github.run_id }}"
           head_sha: ${{ steps.pr.outputs.head_sha }}
           conclusion: "failure"
@@ -107,7 +108,7 @@ jobs:
           mediaType: |
             previews:
               - antiope
-          name: "wiby"
+          name: ${{ env.WIBY_CHECK_NAME }}
           details_url: "${{ steps.pr.outputs.repo_url }}/actions/runs/${{ github.run_id }}"
           head_sha: ${{ steps.pr.outputs.head_sha }}
           status: "in_progress"
@@ -192,7 +193,7 @@ jobs:
           mediaType: |
             previews:
               - antiope
-          name: "wiby"
+          name: ${{ env.WIBY_CHECK_NAME }}
           details_url: "${{ steps.pr.outputs.repo_url }}/actions/runs/${{ github.run_id }}"
           head_sha: ${{ steps.pr.outputs.head_sha }}
           conclusion: "failure"
@@ -208,7 +209,7 @@ jobs:
           mediaType: |
             previews:
               - antiope
-          name: "wiby"
+          name: ${{ env.WIBY_CHECK_NAME }}
           details_url: "${{ steps.pr.outputs.repo_url }}/actions/runs/${{ github.run_id }}"
           head_sha: ${{ steps.pr.outputs.head_sha }}
           conclusion: ${{ steps.wiby_result.outputs.wiby_conclusion }}

--- a/.github/workflows/wiby.yaml
+++ b/.github/workflows/wiby.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
 
       - name: Load PR
-        uses: octokit/request-action@v2.0.0
+        uses: octokit/request-action@v2.x
         with:
           route: ${{ github.event.issue.pull_request.url }}
         env:
@@ -125,7 +125,7 @@ jobs:
     steps:
 
       - name: Load PR
-        uses: octokit/request-action@v2.0.0
+        uses: octokit/request-action@v2.x
         with:
           route: ${{ github.event.issue.pull_request.url }}
         env:

--- a/.github/workflows/wiby.yaml
+++ b/.github/workflows/wiby.yaml
@@ -1,0 +1,216 @@
+name: wiby
+
+on:
+  issue_comment:
+    types: [ created ]
+
+env:
+  WIBY_NODE_VERSION: 14
+
+jobs:
+
+  permissions:
+
+    runs-on: ubuntu-latest
+
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, 'wiby ') && (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR') }}
+
+    steps:
+      - run: 'echo "Author association: ${{ github.event.comment.author_association }}"'
+
+  test:
+
+    runs-on: ubuntu-latest
+
+    needs: permissions
+
+    if: ${{ startsWith(github.event.comment.body, 'wiby test') }}
+
+    steps:
+
+      - name: Load PR
+        uses: octokit/request-action@v2.0.0
+        with:
+          route: ${{ github.event.issue.pull_request.url }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        id: load_pr
+
+      - name: Get PR information
+        run: |
+          echo "::set-output name=branch::${{ fromJson(steps.load_pr.outputs.data).head.ref }}"
+          echo "::set-output name=head_sha::${{ fromJson(steps.load_pr.outputs.data).head.sha }}"
+          echo "::set-output name=repo_name::${{ fromJson(steps.load_pr.outputs.data).base.repo.full_name }}"
+          echo "::set-output name=repo_url::${{ fromJson(steps.load_pr.outputs.data).base.repo.html_url }}"
+        id: pr
+
+      - name: Set "queued" status
+        uses: octokit/request-action@v2.x
+        with:
+          route: POST /repos/:repository/check-runs
+          repository: ${{ steps.pr.outputs.repo_name }}
+          mediaType: |
+            previews:
+              - antiope
+          name: "wiby"
+          details_url: "${{ steps.pr.outputs.repo_url }}/actions/runs/${{ github.run_id }}"
+          head_sha: ${{ steps.pr.outputs.head_sha }}
+          status: "queued"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout PR Branch
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ steps.pr.outputs.repo_name }}
+          ref: ${{ steps.pr.outputs.branch }}
+
+      - name: Prepare Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.WIBY_NODE_VERSION }}
+
+      - name: wiby test
+        run: |
+          if cat package.json | jq -e '.scripts["action-wiby-test"]'; then
+            # this is primarily so that wiby can test itself using itself
+            npm run action-wiby-test
+          else
+            npm install
+            npx wiby test
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.WIBY_TOKEN }}
+
+      - name: Handle errors
+        uses: octokit/request-action@v2.x
+        if: ${{ failure() }}
+        with:
+          route: POST /repos/:repository/check-runs
+          repository: ${{ steps.pr.outputs.repo_name }}
+          mediaType: |
+            previews:
+              - antiope
+          name: "wiby"
+          details_url: "${{ steps.pr.outputs.repo_url }}/actions/runs/${{ github.run_id }}"
+          head_sha: ${{ steps.pr.outputs.head_sha }}
+          conclusion: "failure"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set "in_progress" status
+        uses: octokit/request-action@v2.x
+        with:
+          route: POST /repos/:repository/check-runs
+          repository: ${{ steps.pr.outputs.repo_name }}
+          mediaType: |
+            previews:
+              - antiope
+          name: "wiby"
+          details_url: "${{ steps.pr.outputs.repo_url }}/actions/runs/${{ github.run_id }}"
+          head_sha: ${{ steps.pr.outputs.head_sha }}
+          status: "in_progress"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  result:
+
+    runs-on: ubuntu-latest
+
+    needs: permissions
+
+    if: ${{ startsWith(github.event.comment.body, 'wiby result') }}
+
+    steps:
+
+      - name: Load PR
+        uses: octokit/request-action@v2.0.0
+        with:
+          route: ${{ github.event.issue.pull_request.url }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        id: load_pr
+
+      - name: Get PR information
+        run: |
+          echo "::set-output name=branch::${{ fromJson(steps.load_pr.outputs.data).head.ref }}"
+          echo "::set-output name=head_sha::${{ fromJson(steps.load_pr.outputs.data).head.sha }}"
+          echo "::set-output name=repo_name::${{ fromJson(steps.load_pr.outputs.data).base.repo.full_name }}"
+          echo "::set-output name=repo_url::${{ fromJson(steps.load_pr.outputs.data).base.repo.html_url }}"
+        id: pr
+
+      - name: Checkout PR Branch
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ steps.pr.outputs.repo_name }}
+          ref: ${{ steps.pr.outputs.branch }}
+
+      - name: Prepare Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.WIBY_NODE_VERSION }}
+
+      - name: wiby result
+        run: |
+          # execute wiby result and set action result
+
+          handle_result() {
+
+            WIBY_RESULT_CODE=$1
+
+            if [ ${WIBY_RESULT_CODE} -eq 64 ]; then
+              echo "`wiby` exited with code 64 - results are still pending"
+            else
+              echo "::set-output name=wiby_conclusion::failure"
+            fi
+
+          }
+
+          if cat package.json | jq -e '.scripts["action-wiby-result"]'; then
+            # this is primarily so that wiby can test itself using itself
+            npm run action-wiby-result || handle_result $?
+          else
+            npm install
+            npx wiby result || handle_result $?
+          fi
+
+          # if we got here - there was no error
+          echo "::set-output name=wiby_conclusion::success"
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.WIBY_TOKEN }}
+        id: wiby_result
+
+      - name: Handle errors
+        uses: octokit/request-action@v2.x
+        if: ${{ failure() }}
+        with:
+          route: POST /repos/:repository/check-runs
+          repository: ${{ steps.pr.outputs.repo_name }}
+          mediaType: |
+            previews:
+              - antiope
+          name: "wiby"
+          details_url: "${{ steps.pr.outputs.repo_url }}/actions/runs/${{ github.run_id }}"
+          head_sha: ${{ steps.pr.outputs.head_sha }}
+          conclusion: "failure"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set status from result
+        uses: octokit/request-action@v2.x
+        if: ${{ steps.wiby_result.outputs.wiby_conclusion != '' }}
+        with:
+          route: POST /repos/:repository/check-runs
+          repository: ${{ steps.pr.outputs.repo_name }}
+          mediaType: |
+            previews:
+              - antiope
+          name: "wiby"
+          details_url: "${{ steps.pr.outputs.repo_url }}/actions/runs/${{ github.run_id }}"
+          head_sha: ${{ steps.pr.outputs.head_sha }}
+          conclusion: ${{ steps.wiby_result.outputs.wiby_conclusion }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -1,0 +1,18 @@
+# wiby github workflow
+
+The `wiby` workflow for Github is very much work in progress, but please ask questions in the issue tracker.
+
+## Installation / Upgrading
+
+This is a manual step, until automation is ready:
+
+1. Install `wiby` as a dev dependency (and update to latest version)
+   - having it as a dev dep is not strictly necessary, as the workflow relies on `npx wiby`, but it does give control over the installed version
+2. `mkdir -p .github/workflows && npm explore wiby -- cat .github/workflows/wiby.yaml > .github/workflows/wiby.yaml` 
+   - Duplicate the default `wiby` workflow - the automation, when developed, will attempt to keep it up to date at that location
+3. Make sure your `.github/workflows/wiby.yaml` ends up on the default (`main`, `master`) branch on Github
+   - i.e. commit, push, open a PR and merge it, if necessary
+4. Add a `WIBY_TOKEN` secret
+   - create a new one at https://github.com/settings/tokens, required scopes: `repo:status` and `public_repo`
+   - the account has to have push access to the test repositories - you will probably want to fork the dependents into that account (or a separate organization)
+   - you may want to use a robot account which _does not have **any** merge access_, as Github does not allow restricting tokens to a subset of repositories

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -14,8 +14,9 @@ This is a manual step, until automation is ready:
    - i.e. commit, push, open a PR and merge it, if necessary
 4. Add a `WIBY_TOKEN` secret
    - create a new one at https://github.com/settings/tokens, required scopes: `repo:status` and `public_repo`
-   - the account has to have push access to the test repositories - you will probably want to fork the dependents into that account (or a separate organization)
+   - the account has to have _push_ (merge access not necessary) access to the test repositories - you will probably want to fork the dependents into that account (or a separate organization)
    - you may want to use a robot account which _does not have **any** merge access_, as Github does not allow restricting tokens to a subset of repositories
+   - the bot account does not need to have access to the original repository (only to the forks used for testing)
 
 
 ## Usage

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -16,3 +16,15 @@ This is a manual step, until automation is ready:
    - create a new one at https://github.com/settings/tokens, required scopes: `repo:status` and `public_repo`
    - the account has to have push access to the test repositories - you will probably want to fork the dependents into that account (or a separate organization)
    - you may want to use a robot account which _does not have **any** merge access_, as Github does not allow restricting tokens to a subset of repositories
+
+
+## Usage
+
+0. This assumes `.wiby.json` is already configured and that you're an owner or a contributor on the dependency repo
+1. Open a PR against the dependency repository
+2. Post a comment saying `wiby test` in the PR
+   - This should kick off the test workflow and update the `package.json` of configured dependents
+   - Shortly after that, a `wiby` status check will have its status set to `pending`
+3. Wait a reasonable amount of time for the dependents to finish their tests
+4. Post a comment saying `wiby result`
+   - Shortly after that, the `wiby` status check will changes its status to report the results of the tests in the dependents (but it may stay pending if they're still running)

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "test": "test"
   },
   "scripts": {
+    "action-wiby-test": "npm install --production && ./bin/wiby test",
+    "action-wiby-result": "npm install --production && ./bin/wiby result",
     "lint": "standard",
     "pretest": "npm run lint",
     "test": "npm run tests-only",


### PR DESCRIPTION
See https://github.com/pkgjs/wiby/pull/69/files#diff-00505182d7d4129a98ee7fb7b652a1ef6b608d7620a681914db3a7a4903eee9f for usage details.

Marking this ready for review to get feedback, but we can't merge this without the following:

- [x] Create a bot account - https://github.com/wiby-bot
- [x] Add the `WIBY_TOKEN`

I have also added a bunch of notes on https://github.com/pkgjs/wiby/issues/56#issuecomment-768301949 on how to move this forward, but I figure I'll want to make some changes to the wiby CLI first, rather than the GH actions, and I'd also like to start getting this to a more demoable place and also to start test driving this on wiby itself, even if it still requires some manual interaction (namely deleting the `wiby-wiby` branch in the `wiby-test` org).
