### PR TITLE
fix: default branch assumes *master*

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -15,7 +15,7 @@ module.exports.getPackageJson = async function getPackageJson (owner, repo) {
     const resp = await graphqlWithAuth({
       query: `query($owner: String!, $repo: String!) {
         repository(name: $repo, owner: $owner) {
-          object(expression: "master:package.json") {
+          object(expression: "HEAD:package.json") {
             ... on Blob {
               text
             }


### PR DESCRIPTION
During testing using a [parent repo](https://github.com/ghinks/my-parent) that [had a dependency upon](https://github.com/ghinks/my-dependency-id-a).

The repos did not use *master* but *main* I found issues as the default branch was hardcoded to *master*.

From your suggestion I have changed this to use the HEAD query.
