### PR TITLE
Upgrade `tap` to v15

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "nock": "^13.0.3",
     "standard": "^16.0.0",
-    "tap": "^14.10.7",
+    "tap": "^15.0.0",
     "tmp": "^0.2.1"
   },
   "standard": {

--- a/test/cli/clean.js
+++ b/test/cli/clean.js
@@ -21,10 +21,10 @@ tap.test('clean command', async (tap) => {
         NODE_OPTIONS: `-r ${fixturesPath}/http/clean-command.js`
       }
     }).toString()
-    tap.includes(result, 'Branches deleted:')
-    tap.includes(result, '- https://github.com/wiby-test/partial: wiby-running-unit-tests')
-    tap.includes(result, '- git://github.com/wiby-test/fail: wiby-running-unit-tests')
-    tap.includes(result, '- git+https://github.com/wiby-test/pass: wiby-running-unit-tests')
+    tap.match(result, 'Branches deleted:')
+    tap.match(result, '- https://github.com/wiby-test/partial: wiby-running-unit-tests')
+    tap.match(result, '- git://github.com/wiby-test/fail: wiby-running-unit-tests')
+    tap.match(result, '- git+https://github.com/wiby-test/pass: wiby-running-unit-tests')
   })
 
   tap.test('should delete test branch in the test module at dependent URI', async (tap) => {
@@ -34,8 +34,8 @@ tap.test('clean command', async (tap) => {
         NODE_OPTIONS: `-r ${fixturesPath}/http/clean-command.js`
       }
     }).toString()
-    tap.includes(result, 'Branches deleted:')
-    tap.includes(result, '- https://github.com/wiby-test/fakeRepo: wiby-running-unit-tests')
+    tap.match(result, 'Branches deleted:')
+    tap.match(result, '- https://github.com/wiby-test/fakeRepo: wiby-running-unit-tests')
   })
 
   tap.test('should delete all wiby-* branches in all configured test modules', async (tap) => {
@@ -45,10 +45,10 @@ tap.test('clean command', async (tap) => {
         NODE_OPTIONS: `-r ${fixturesPath}/http/clean-command-all.js`
       }
     }).toString()
-    tap.includes(result, 'Branches deleted:')
-    tap.includes(result, '- https://github.com/wiby-test/partial: wiby-partial-one, wiby-partial-two')
-    tap.includes(result, '- git://github.com/wiby-test/fail: wiby-fail-one, wiby-fail-two')
-    tap.includes(result, '- git+https://github.com/wiby-test/pass: wiby-pass-one, wiby-pass-two')
+    tap.match(result, 'Branches deleted:')
+    tap.match(result, '- https://github.com/wiby-test/partial: wiby-partial-one, wiby-partial-two')
+    tap.match(result, '- git://github.com/wiby-test/fail: wiby-fail-one, wiby-fail-two')
+    tap.match(result, '- git+https://github.com/wiby-test/pass: wiby-pass-one, wiby-pass-two')
   })
 
   tap.test('should not delete during dry-run', async (tap) => {
@@ -59,9 +59,9 @@ tap.test('clean command', async (tap) => {
       }
     }).toString()
 
-    tap.includes(result, 'Branches to be deleted:')
-    tap.includes(result, '- https://github.com/wiby-test/partial: wiby-running-unit-tests')
-    tap.includes(result, '- git://github.com/wiby-test/fail: wiby-running-unit-tests')
-    tap.includes(result, '- git+https://github.com/wiby-test/pass: wiby-running-unit-tests')
+    tap.match(result, 'Branches to be deleted:')
+    tap.match(result, '- https://github.com/wiby-test/partial: wiby-running-unit-tests')
+    tap.match(result, '- git://github.com/wiby-test/fail: wiby-running-unit-tests')
+    tap.match(result, '- git+https://github.com/wiby-test/pass: wiby-running-unit-tests')
   })
 })

--- a/test/cli/github-workflow-install.js
+++ b/test/cli/github-workflow-install.js
@@ -61,7 +61,7 @@ tap.test('github-workflow install command', async (tap) => {
       })
       tap.fail('Should fail before reaching here')
     } catch (err) {
-      tap.include(err.message, '/.github/workflows folder does not exist.')
+      tap.match(err.message, '/.github/workflows folder does not exist.')
     }
   })
 })

--- a/test/cli/github-workflow-outdated.js
+++ b/test/cli/github-workflow-outdated.js
@@ -24,7 +24,7 @@ tap.test('github-workflow outdated command', async (tap) => {
       })
       tap.fail('Should fail before reaching here')
     } catch (err) {
-      tap.include(err.message, '/.github/workflows/wiby.yaml not found. Use `wiby github-workflow install` to install it.')
+      tap.match(err.message, '/.github/workflows/wiby.yaml not found. Use `wiby github-workflow install` to install it.')
     }
   })
 
@@ -45,7 +45,7 @@ tap.test('github-workflow outdated command', async (tap) => {
       })
       tap.fail('Should fail before reaching here')
     } catch (err) {
-      tap.include(err.message, '/.github/workflows/wiby.yaml is not the same as the bundled version')
+      tap.match(err.message, '/.github/workflows/wiby.yaml is not the same as the bundled version')
     }
   })
 
@@ -64,7 +64,7 @@ tap.test('github-workflow outdated command', async (tap) => {
       }
     }).toString()
 
-    tap.include(result, 'wiby.yaml is the same as the bundled version.')
+    tap.match(result, 'wiby.yaml is the same as the bundled version.')
   })
 
   tap.test('should pass when wiby.yaml has the same contents in $INIT_CWD', async (tap) => {
@@ -83,6 +83,6 @@ tap.test('github-workflow outdated command', async (tap) => {
       }
     }).toString()
 
-    tap.include(result, 'wiby.yaml is the same as the bundled version.')
+    tap.match(result, 'wiby.yaml is the same as the bundled version.')
   })
 })

--- a/test/cli/result.js
+++ b/test/cli/result.js
@@ -94,6 +94,30 @@ tap.test('result command', async (tap) => {
     tap.end()
   })
 
+  tap.test('result command handles flat response from github.getCommitStatusesForRef()', (tap) => {
+    const expected = fs.readFileSync(
+      path.join(__dirname, '..', 'fixtures', 'expected-outputs', 'result', 'result-output-single-dependant.md'),
+      'utf-8'
+    )
+      .trim()
+
+    try {
+      childProcess.execSync(`${wibyCommand} result --dependent="https://github.com/wiby-test/fakeRepo"`, {
+        env: {
+          ...process.env,
+          NODE_OPTIONS: `-r ${fixturesPath}/http/result-command-empty-branch-checks-flat.js`
+        }
+      })
+    } catch (e) {
+      const result = e.output[1].toString().trim()
+
+      tap.equal(result, expected)
+      tap.equal(e.status, PENDING_RESULT_EXIT_CODE)
+    }
+
+    tap.end()
+  })
+
   tap.test('result command should exit with code 1 for overall failed status', async (tap) => {
     const expected = fs.readFileSync(
       path.join(__dirname, '..', 'fixtures', 'expected-outputs', 'result', 'result-output-single-dependant-check-failed.md'),

--- a/test/cli/test.js
+++ b/test/cli/test.js
@@ -31,7 +31,7 @@ tap.test('test command', async (tap) => {
       }
     }).toString()
 
-    tap.includes(result, 'Changes pushed to https://github.com/wiby-test/fakeRepo/blob/wiby-running-unit-tests/package.json')
+    tap.match(result, 'Changes pushed to https://github.com/wiby-test/fakeRepo/blob/wiby-running-unit-tests/package.json')
   })
 
   tap.test('test command should call test module with all deps from .wiby.json', async (tap) => {
@@ -42,8 +42,8 @@ tap.test('test command', async (tap) => {
       }
     }).toString()
 
-    tap.includes(result, 'Changes pushed to https://github.com/wiby-test/pass/blob/wiby-running-unit-tests/package.json')
-    tap.includes(result, 'Changes pushed to https://github.com/wiby-test/fail/blob/wiby-running-unit-tests/package.json')
-    tap.includes(result, 'Changes pushed to https://github.com/wiby-test/partial/blob/wiby-running-unit-tests/package.json')
+    tap.match(result, 'Changes pushed to https://github.com/wiby-test/pass/blob/wiby-running-unit-tests/package.json')
+    tap.match(result, 'Changes pushed to https://github.com/wiby-test/fail/blob/wiby-running-unit-tests/package.json')
+    tap.match(result, 'Changes pushed to https://github.com/wiby-test/partial/blob/wiby-running-unit-tests/package.json')
   })
 })

--- a/test/fixtures/http/result-command-empty-branch-checks-flat.js
+++ b/test/fixtures/http/result-command-empty-branch-checks-flat.js
@@ -1,0 +1,39 @@
+'use strict'
+
+/**
+ * Mocks of HTTP calls for "wiby result" command flow with empty response from check-runs
+ */
+const nock = require('nock')
+
+nock.disableNetConnect()
+
+nock('https://api.github.com')
+  // get package json
+  .post('/graphql')
+  .reply(200, {
+    data: {
+      repository: {
+        object: {
+          text: JSON.stringify({
+            dependencies: {
+              wiby: '*'
+            }
+          })
+        }
+      }
+    }
+  })
+  // get check results
+  .get('/repos/wiby-test/fakeRepo/commits/wiby-running-unit-tests/check-runs')
+  .reply(200, {
+    check_runs: [
+      // empty checks list
+    ]
+  })
+  // get checks for ref
+  .get('/repos/wiby-test/fakeRepo/commits/wiby-running-unit-tests/statuses')
+  .reply(200, [
+    // !!! Notable change is here - result returned as array instead of object with check_runs field
+    { status: 'queued', name: 'fake_run' },
+    { status: 'done', name: 'fake_run_2', conclusion: 'fake_conclusion' }
+  ])

--- a/test/internals/github-integration.js
+++ b/test/internals/github-integration.js
@@ -7,7 +7,7 @@ const CONFIG = require('../fixtures/config')
 
 tap.test('package.json can be fetched with a valid url', async tap => {
   const packageJson = await github.getPackageJson(CONFIG.DEP_ORG, CONFIG.DEP_REPO)
-  tap.includes(packageJson, { ...CONFIG.PKGJSON, dependencies: { [CONFIG.PKG_NAME_INTEGRATION]: '*' } })
+  tap.match(packageJson, { ...CONFIG.PKGJSON, dependencies: { [CONFIG.PKG_NAME_INTEGRATION]: '*' } })
 }, { skip: !process.env.GITHUB_TOKEN })
 
 tap.test('Shas returned from getShas', async tap => {

--- a/test/result.js
+++ b/test/result.js
@@ -52,7 +52,7 @@ tap.test('wiby.result()', async (tap) => {
   })
 
   tap.test('result() should return correct data object', async (tap) => {
-    // mock reall http requests with positive scenario
+    // mock real http requests with positive scenario
     require('./fixtures/http/result-command-positive')
 
     const output = await wiby.result({ dependents: [{ repository: 'https://github.com/wiby-test/fakeRepo' }] })
@@ -106,5 +106,17 @@ tap.test('wiby.result()', async (tap) => {
     tap.equal(wiby.result.getOverallStatusForAllRuns(pendingCasesPresent), 'pending')
     tap.equal(wiby.result.getOverallStatusForAllRuns(queuedCasesPresent), 'pending')
     tap.equal(wiby.result.getOverallStatusForAllRuns(successCasesPresent), 'success')
+  })
+
+  tap.test('resolveCodeAndExit() should exit with 0 code with "success" status', async (tap) => {
+    try {
+      wiby.result.processOutput({
+        status: 'success',
+        results: []
+      })
+      tap.pass()
+    } catch (e) {
+      tap.fail('Should not get here')
+    }
   })
 })


### PR DESCRIPTION
We were affected by 2 major changes in `tap` v15:

1. Separate `tap.has` (`tap.include()`) from `tap.match`, so these are distinct.
It was required to change `tap.include()` to `tap.match()` as next code is behaves on v15 like this:
```javascript
tap.test('test 15', async (tap) => {
  const string = 'some text expected'
  tap.include(string, 'expected') // will fail
  tap.match(string, 'expected') // will pass
})
````
2. `--check-coverage` on by default.
Tap started to fail by default in case coverage is under 100%.
So I added few more tests to be in "100% Coverage Club 🏅"

Related to #89 