### PR TITLE
Use `wiby test` label as a trigger

### DIFF
--- a/.github/workflows/wiby.yaml
+++ b/.github/workflows/wiby.yaml
@@ -61,7 +61,6 @@ jobs:
             previews:
               - antiope
           name: ${{ env.WIBY_CHECK_NAME }}
-          details_url: "${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}"
           head_sha: ${{ github.event.pull_request.head.sha }}
           status: "queued"
         env:
@@ -101,7 +100,6 @@ jobs:
             previews:
               - antiope
           name: ${{ env.WIBY_CHECK_NAME }}
-          details_url: "${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}"
           head_sha: ${{ github.event.pull_request.head.sha }}
           conclusion: "failure"
         env:
@@ -116,7 +114,6 @@ jobs:
             previews:
               - antiope
           name: ${{ env.WIBY_CHECK_NAME }}
-          details_url: "${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}"
           head_sha: ${{ github.event.pull_request.head.sha }}
           status: "in_progress"
         env:
@@ -199,7 +196,6 @@ jobs:
             previews:
               - antiope
           name: ${{ env.WIBY_CHECK_NAME }}
-          details_url: "${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}"
           head_sha: ${{ github.event.pull_request.head.sha }}
           conclusion: "failure"
         env:
@@ -215,7 +211,6 @@ jobs:
             previews:
               - antiope
           name: ${{ env.WIBY_CHECK_NAME }}
-          details_url: "${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}"
           head_sha: ${{ github.event.pull_request.head.sha }}
           conclusion: ${{ steps.wiby_result.outputs.wiby_conclusion }}
         env:

--- a/.github/workflows/wiby.yaml
+++ b/.github/workflows/wiby.yaml
@@ -122,6 +122,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Clean up the trigger label
+        if: ${{ always() }}
+        uses: octokit/request-action@v2.x
+        with:
+          route: DELETE /repos/:repository/issues/:issue_number/labels/:label_name
+          repository: ${{ github.event.repository.full_name }}
+          issue_number: ${{ github.event.pull_request.number }}
+          label_name: ${{ github.event.label.name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
   result:
 
     runs-on: ubuntu-latest
@@ -206,5 +218,16 @@ jobs:
           details_url: "${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}"
           head_sha: ${{ github.event.pull_request.head.sha }}
           conclusion: ${{ steps.wiby_result.outputs.wiby_conclusion }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Clean up the trigger label
+        if: ${{ always() }}
+        uses: octokit/request-action@v2.x
+        with:
+          route: DELETE /repos/:repository/issues/:issue_number/labels/:label_name
+          repository: ${{ github.event.repository.full_name }}
+          issue_number: ${{ github.event.pull_request.number }}
+          label_name: ${{ github.event.label.name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wiby.yaml
+++ b/.github/workflows/wiby.yaml
@@ -1,8 +1,8 @@
 name: wiby
 
 on:
-  issue_comment:
-    types: [ created ]
+  pull_request:
+    types: [ labeled ]
 
 env:
   WIBY_CHECK_NAME: "wiby"
@@ -10,29 +10,52 @@ env:
 
 jobs:
 
-  permissions:
+  status:
 
     runs-on: ubuntu-latest
 
-    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, 'wiby ') && (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR') }}
+    if: ${{ github.event.label.name == 'wiby test' }}
+
+    outputs:
+      in_progress: ${{ steps.checks_by_status.outputs.in_progress }}
+      queued: ${{ steps.checks_by_status.outputs.queued }}
+      completed: ${{ steps.checks_by_status.outputs.completed }}
 
     steps:
-      - run: 'echo "Author association: ${{ github.event.comment.author_association }}"'
+      - name: Get status
+        uses: octokit/request-action@v2.x
+        with:
+          route: GET /repos/:repository/commits/:ref/check-runs
+          repository: ${{ github.event.repository.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          mediaType: |
+            previews:
+              - antiope
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        id: pr_status
+
+      - name: Count wiby status check by their status
+        run: |
+          jq -r '.check_runs | map(select(.name=="wiby")) | group_by(.status) | map("::set-output name=" + .[0].status + "::" + (length | tostring)) | join("\n")' << EOF
+          ${{ steps.pr_status.outputs.data }}
+          EOF
+        id: checks_by_status
 
   test:
 
     runs-on: ubuntu-latest
 
-    needs: permissions
+    needs: status
 
-    if: ${{ startsWith(github.event.comment.body, 'wiby test') }}
+    if: ${{ !needs.status.outputs.in_progress && !needs.status.outputs.queued }}
 
     steps:
 
       - name: Load PR
         uses: octokit/request-action@v2.x
         with:
-          route: ${{ github.event.issue.pull_request.url }}
+          route: ${{ github.event.pull_request.url }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         id: load_pr
@@ -119,9 +142,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    needs: permissions
+    needs: status
 
-    if: ${{ startsWith(github.event.comment.body, 'wiby result') }}
+    if: ${{ needs.status.outputs.in_progress }}
 
     steps:
 

--- a/.github/workflows/wiby.yaml
+++ b/.github/workflows/wiby.yaml
@@ -52,33 +52,17 @@ jobs:
 
     steps:
 
-      - name: Load PR
-        uses: octokit/request-action@v2.x
-        with:
-          route: ${{ github.event.pull_request.url }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        id: load_pr
-
-      - name: Get PR information
-        run: |
-          echo "::set-output name=branch::${{ fromJson(steps.load_pr.outputs.data).head.ref }}"
-          echo "::set-output name=head_sha::${{ fromJson(steps.load_pr.outputs.data).head.sha }}"
-          echo "::set-output name=repo_name::${{ fromJson(steps.load_pr.outputs.data).base.repo.full_name }}"
-          echo "::set-output name=repo_url::${{ fromJson(steps.load_pr.outputs.data).base.repo.html_url }}"
-        id: pr
-
       - name: Set "queued" status
         uses: octokit/request-action@v2.x
         with:
           route: POST /repos/:repository/check-runs
-          repository: ${{ steps.pr.outputs.repo_name }}
+          repository: ${{ github.event.repository.full_name }}
           mediaType: |
             previews:
               - antiope
           name: ${{ env.WIBY_CHECK_NAME }}
-          details_url: "${{ steps.pr.outputs.repo_url }}/actions/runs/${{ github.run_id }}"
-          head_sha: ${{ steps.pr.outputs.head_sha }}
+          details_url: "${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}"
+          head_sha: ${{ github.event.pull_request.head.sha }}
           status: "queued"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -87,8 +71,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ steps.pr.outputs.repo_name }}
-          ref: ${{ steps.pr.outputs.branch }}
+          repository: ${{ github.event.repository.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Prepare Node.js
         uses: actions/setup-node@v2
@@ -112,13 +96,13 @@ jobs:
         if: ${{ failure() }}
         with:
           route: POST /repos/:repository/check-runs
-          repository: ${{ steps.pr.outputs.repo_name }}
+          repository: ${{ github.event.repository.full_name }}
           mediaType: |
             previews:
               - antiope
           name: ${{ env.WIBY_CHECK_NAME }}
-          details_url: "${{ steps.pr.outputs.repo_url }}/actions/runs/${{ github.run_id }}"
-          head_sha: ${{ steps.pr.outputs.head_sha }}
+          details_url: "${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}"
+          head_sha: ${{ github.event.pull_request.head.sha }}
           conclusion: "failure"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -127,13 +111,13 @@ jobs:
         uses: octokit/request-action@v2.x
         with:
           route: POST /repos/:repository/check-runs
-          repository: ${{ steps.pr.outputs.repo_name }}
+          repository: ${{ github.event.repository.full_name }}
           mediaType: |
             previews:
               - antiope
           name: ${{ env.WIBY_CHECK_NAME }}
-          details_url: "${{ steps.pr.outputs.repo_url }}/actions/runs/${{ github.run_id }}"
-          head_sha: ${{ steps.pr.outputs.head_sha }}
+          details_url: "${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}"
+          head_sha: ${{ github.event.pull_request.head.sha }}
           status: "in_progress"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -148,28 +132,12 @@ jobs:
 
     steps:
 
-      - name: Load PR
-        uses: octokit/request-action@v2.x
-        with:
-          route: ${{ github.event.issue.pull_request.url }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        id: load_pr
-
-      - name: Get PR information
-        run: |
-          echo "::set-output name=branch::${{ fromJson(steps.load_pr.outputs.data).head.ref }}"
-          echo "::set-output name=head_sha::${{ fromJson(steps.load_pr.outputs.data).head.sha }}"
-          echo "::set-output name=repo_name::${{ fromJson(steps.load_pr.outputs.data).base.repo.full_name }}"
-          echo "::set-output name=repo_url::${{ fromJson(steps.load_pr.outputs.data).base.repo.html_url }}"
-        id: pr
-
       - name: Checkout PR Branch
         uses: actions/checkout@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ steps.pr.outputs.repo_name }}
-          ref: ${{ steps.pr.outputs.branch }}
+          repository: ${{ github.event.repository.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Prepare Node.js
         uses: actions/setup-node@v2
@@ -214,13 +182,13 @@ jobs:
         if: ${{ failure() }}
         with:
           route: POST /repos/:repository/check-runs
-          repository: ${{ steps.pr.outputs.repo_name }}
+          repository: ${{ github.event.repository.full_name }}
           mediaType: |
             previews:
               - antiope
           name: ${{ env.WIBY_CHECK_NAME }}
-          details_url: "${{ steps.pr.outputs.repo_url }}/actions/runs/${{ github.run_id }}"
-          head_sha: ${{ steps.pr.outputs.head_sha }}
+          details_url: "${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}"
+          head_sha: ${{ github.event.pull_request.head.sha }}
           conclusion: "failure"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -230,13 +198,13 @@ jobs:
         if: ${{ steps.wiby_result.outputs.wiby_conclusion != '' }}
         with:
           route: POST /repos/:repository/check-runs
-          repository: ${{ steps.pr.outputs.repo_name }}
+          repository: ${{ github.event.repository.full_name }}
           mediaType: |
             previews:
               - antiope
           name: ${{ env.WIBY_CHECK_NAME }}
-          details_url: "${{ steps.pr.outputs.repo_url }}/actions/runs/${{ github.run_id }}"
-          head_sha: ${{ steps.pr.outputs.head_sha }}
+          details_url: "${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}"
+          head_sha: ${{ github.event.pull_request.head.sha }}
           conclusion: ${{ steps.wiby_result.outputs.wiby_conclusion }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wiby.yaml
+++ b/.github/workflows/wiby.yaml
@@ -185,7 +185,7 @@ jobs:
             WIBY_RESULT_CODE=$1
 
             if [ ${WIBY_RESULT_CODE} -eq 64 ]; then
-              echo "`wiby` exited with code 64 - results are still pending"
+              echo "wiby exited with code 64 - results are still pending"
               exit
             else
               echo "::set-output name=wiby_conclusion::failure"

--- a/.github/workflows/wiby.yaml
+++ b/.github/workflows/wiby.yaml
@@ -1,7 +1,7 @@
 name: wiby
 
 on:
-  pull_request:
+  pull_request_target:
     types: [ labeled ]
 
 env:


### PR DESCRIPTION
Implemented as described in https://github.com/pkgjs/wiby/issues/56#issuecomment-887602099

I might have to review the interactions with the checks API - something changed in Github and I was not getting the main `wiby` status displayed on the PR, but otherwise this works.

Some other notes to follow up:

- ~~Does it work OK when PR is opened from a fork? Mainly does the `checkout` action step, which uses the `github.event.pull_request.head.ref`, check out the correct branch/give it the correct name?~~ It does not #107 
- ~~Still need to figure out an option for retest~~ Deferred to https://github.com/pkgjs/wiby/issues/109
- ~~Still need to figure out when is a good time to do `wiby clean`~~ Forgot it's covered in #96 
- ~~Probably need to remove the label if neither test nor results run~~ Covered in https://github.com/pkgjs/wiby/issues/109

cc @zekth