### PR TITLE
fix: close-pr count included unsuccessful runs

### DIFF
--- a/lib/closePR.js
+++ b/lib/closePR.js
@@ -16,7 +16,7 @@ module.exports = async ({ dependents }) => {
       const branch = await context.getTestingBranchName(parentBranchName)
       const resp = await github.getChecks(dependentPkgInfo.owner, dependentPkgInfo.name, branch)
       const closedPR = await closeDependencyPR(dependentPkgInfo.owner, dependentPkgInfo.name, branch, resp.data.check_runs)
-      if (closedPR) {
+      if (closedPR && closedPR.length > 0) {
         closedPrs.push(closedPR)
       }
     }


### PR DESCRIPTION
Changed the result to look at whether the array actually had a length as on testing I found that it always said "1 PRs closed" when closing a failing PR.

During the writing of the documents I created a failing PR from the dependency and the wiby close-pr command was always saying that it was closing it when in fact it was not. The promise all was returning an empty array.
