### PR TITLE
security: rely on `sha` rather than `ref`

### DIFF
--- a/.github/workflows/wiby.yaml
+++ b/.github/workflows/wiby.yaml
@@ -71,7 +71,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.repository.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Prepare Node.js
         uses: actions/setup-node@v2
@@ -146,7 +146,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.repository.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Prepare Node.js
         uses: actions/setup-node@v2


### PR DESCRIPTION
Relying on a PR's `sha` is more robust than relying on it's `ref`. The `sha` is unique to a commit, while the `ref` is unique to a branch.