### PR TITLE
fix(tests): update expected error for invalid JSON config

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,12 +36,12 @@
     "dotenv": "^16.0.0",
     "git-url-parse": "^11.1.2",
     "joi": "^17.2.1",
-    "simple-git": "^3.0.0",
     "yargs": "^17.0.0"
   },
   "devDependencies": {
     "nock": "^13.0.3",
     "semver": "^7.7.1",
+    "simple-git": "~3.10",
     "standard": "^16.0.0",
     "tap": "^15.0.0",
     "tmp": "^0.2.1"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "nock": "^13.0.3",
+    "semver": "^7.7.1",
     "standard": "^16.0.0",
     "tap": "^15.0.0",
     "tmp": "^0.2.1"

--- a/test/config.js
+++ b/test/config.js
@@ -7,8 +7,12 @@ const gitFixture = require('./fixtures/git')
 
 const wiby = require('..')
 
+const semver = require('semver')
+const isGTE20 = semver.satisfies(process.versions.node, '>= 20')
+const isGTE22 = semver.satisfies(process.versions.node, '>= 22')
+
 const invalidConfigs = {
-  'fail-bad-json.json': 'Unexpected end of JSON input',
+  'fail-bad-json.json': isGTE20 ? `${path.resolve(path.join(__dirname, 'fixtures', 'config', 'fail-bad-json.json'))}: Expected ':' after property name in JSON at position 23${isGTE22 ? ' (line 2 column 1)' : ''}"` : 'Unexpected end of JSON input',
   'fail-unknown-root-key.json': '"not-allowed" is not allowed',
   'fail-unknown-dependent-key.json': '"dependents[0].sub-key-not-allowed" is not allowed',
   'fail-dependent-not-url.json': '"dependents[0].repository" must be a valid uri'
@@ -51,7 +55,7 @@ tap.test('config validation', async (tap) => {
       tap.test(file, (tap) => {
         tap.throws(() => {
           wiby.validate({ config: path.join(__dirname, 'fixtures', 'config', file) })
-        }, { message: expectedError })
+        }, expectedError)
         tap.end()
       })
     }


### PR DESCRIPTION
Since the error message has changed when reading a JSON with `require`, the best approach would be to not check what message the error contains.

Closes: #147 