### PR TITLE
fix: fix support node 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "dotenv": "^16.0.0",
     "git-url-parse": "^11.1.2",
     "joi": "^17.2.1",
-    "simple-git": "^3.0.0",
+    "simple-git": "3.23.0",
     "yargs": "^17.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
After simple-git@3.24.0, they import the modules with `node:`, which breaks compatibility with Node 12.