### PR TITLE
no use semantic-release

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,3 @@ Example:
   [wiby test](./USAGE.md#wiby-test)    Test your dependents
 
   [wiby result](./USAGE.md#wiby-result) Fetch the results of your tests
-
-## Development
-
-- This repository uses `semantic-release` with default configuration.
-- Create a new release by running `npx semantic-release`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiby",
-  "version": "0.0.0-development",
+  "version": "0.10.1",
   "description": "Will I Break You?",
   "bin": {
     "wiby": "bin/wiby"


### PR DESCRIPTION
I think we can do regular releases without forcing the use of certain patterns that not everyone knows. Additionally, it's easier to approve releases by opening the PR and changing to the version we want rather