### PR TITLE
feat: add linting job to CI workflow and simplify test script

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,5 +27,7 @@ jobs:
 
   test:
     uses: pkgjs/action/.github/workflows/node-test.yaml@main
+    with:
+      upgrade-policy: all
     secrets:
       test-secrets: '{"GITHUB_TOKEN":"${{ secrets.GITHUB_TOKEN }}"}'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,21 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts --include=dev
+
+      - name: Run lint
+        run: npm run lint
 
   test:
     uses: pkgjs/action/.github/workflows/node-test.yaml@main

--- a/package.json
+++ b/package.json
@@ -13,9 +13,7 @@
     "action-wiby-test": "npm install --production && ./bin/wiby test",
     "action-wiby-result": "npm install --production && ./bin/wiby result",
     "lint": "standard",
-    "pretest": "[ \"$NODE_LTS_LATEST\" != \"\" ] && [ \"$MATRIX_NODE_VERSION\" != \"$NODE_LTS_LATEST\" ] && echo 'Skipping linting' || npm run lint",
-    "test": "npm run tests-only",
-    "tests-only": "tap",
+    "test": "tap",
     "generate-docs": "./bin/generate-usage.js"
   },
   "repository": {


### PR DESCRIPTION
The linter is not the tests. I want to run the tests peacefully without worrying about the linter. I can worry about the linter later after finishing my changes.