### PR TITLE
feat: include files in package.json for better distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,12 @@
   "directories": {
     "test": "test"
   },
+  "files": [
+    "lib",
+    "bin",
+    ".github/workflows/wiby.yaml",
+    "package-support.json"
+  ],
   "scripts": {
     "action-wiby-test": "npm install --production && ./bin/wiby test",
     "action-wiby-result": "npm install --production && ./bin/wiby result",


### PR DESCRIPTION
We are sending extra files, ideally, we should only send what is necessary to npm.