### PR TITLE
move simple-git from devDependencies to dependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,12 +36,12 @@
     "dotenv": "^16.0.0",
     "git-url-parse": "^11.1.2",
     "joi": "^17.2.1",
+    "simple-git": "~3.15.0",
     "yargs": "^17.0.0"
   },
   "devDependencies": {
     "nock": "^13.0.3",
     "semver": "^7.7.1",
-    "simple-git": "~3.15.0",
     "standard": "^16.0.0",
     "tap": "^16.0.0",
     "tmp": "^0.2.1"


### PR DESCRIPTION
This is a dependency since it's not used for testing, but for essential package functionality.